### PR TITLE
modified export_encoder.py to work with latest version of onnxruntime

### DIFF
--- a/export_encoder.py
+++ b/export_encoder.py
@@ -55,7 +55,6 @@ torch.onnx.export(model_trace, input_image_torch, output_raw_path,
 quantize_dynamic(
     model_input=output_raw_path,
     model_output=output_path,
-    optimize_model=True,
     per_channel=False,
     reduce_range=False,
     weight_type=QuantType.QUInt8,


### PR DESCRIPTION
I removed the optimize output param in quantize_dynamic because the latest onnxruntime didn't have this parameter. I think this makes sense but let me know if we need to do something more like running a separate optimize method after quantizing. After making this change I was able to export the onnx model and use it in a .Net project without issue.